### PR TITLE
Improve assertions with assertSame and assertNull

### DIFF
--- a/tests/unit/ConditionsTest.php
+++ b/tests/unit/ConditionsTest.php
@@ -16,9 +16,9 @@ class ConditionsTest extends \Codeception\Test\Unit
         $v3 = new Vertex(3, 2);
 
         $cond = new VertexCondition();
-        $this->assertEquals(null, $cond->getVertexTypesOnly());
+        $this->assertNull($cond->getVertexTypesOnly());
         $this->assertEquals([], $cond->getVertexTypesExcluded());
-        $this->assertEquals(null, $cond->getVertexIdsOnly());
+        $this->assertNull($cond->getVertexIdsOnly());
         $this->assertEquals([], $cond->getVertexIdsExcluded());
         $this->assertTrue($cond->isSuitableVertex($v1));
         $this->assertTrue($cond->isSuitableVertex($v2));
@@ -27,32 +27,32 @@ class ConditionsTest extends \Codeception\Test\Unit
         $cond->onlyVertexTypes([1]);
         $this->assertEquals([1], $cond->getVertexTypesOnly());
         $this->assertEquals([], $cond->getVertexTypesExcluded());
-        $this->assertEquals(null, $cond->getVertexIdsOnly());
+        $this->assertNull($cond->getVertexIdsOnly());
         $this->assertEquals([], $cond->getVertexIdsExcluded());
         $this->assertTrue($cond->isSuitableVertex($v1));
         $this->assertTrue($cond->isSuitableVertex($v2));
         $this->assertFalse($cond->isSuitableVertex($v3));
 
         $cond->onlyVertexTypes(null)->excludeVertexTypes([2]);
-        $this->assertEquals(null, $cond->getVertexTypesOnly());
+        $this->assertNull($cond->getVertexTypesOnly());
         $this->assertEquals([2], $cond->getVertexTypesExcluded());
-        $this->assertEquals(null, $cond->getVertexIdsOnly());
+        $this->assertNull($cond->getVertexIdsOnly());
         $this->assertEquals([], $cond->getVertexIdsExcluded());
         $this->assertTrue($cond->isSuitableVertex($v1));
         $this->assertTrue($cond->isSuitableVertex($v2));
         $this->assertFalse($cond->isSuitableVertex($v3));
 
         $cond->excludeVertexIds([2, 3]);
-        $this->assertEquals(null, $cond->getVertexTypesOnly());
+        $this->assertNull($cond->getVertexTypesOnly());
         $this->assertEquals([2], $cond->getVertexTypesExcluded());
-        $this->assertEquals(null, $cond->getVertexIdsOnly());
+        $this->assertNull($cond->getVertexIdsOnly());
         $this->assertEquals([2, 3], $cond->getVertexIdsExcluded());
         $this->assertTrue($cond->isSuitableVertex($v1));
         $this->assertFalse($cond->isSuitableVertex($v2));
         $this->assertFalse($cond->isSuitableVertex($v3));
 
         $cond->excludeVertexIds([])->onlyVertexIds([1]);
-        $this->assertEquals(null, $cond->getVertexTypesOnly());
+        $this->assertNull($cond->getVertexTypesOnly());
         $this->assertEquals([2], $cond->getVertexTypesExcluded());
         $this->assertEquals([1], $cond->getVertexIdsOnly());
         $this->assertEquals([], $cond->getVertexIdsExcluded());
@@ -68,7 +68,7 @@ class ConditionsTest extends \Codeception\Test\Unit
         $e3 = new Edge(3, 2, 3, 1);
 
         $cond = new EdgeCondition();
-        $this->assertEquals(null, $cond->getEdgeTypesOnly());
+        $this->assertNull($cond->getEdgeTypesOnly());
         $this->assertEquals([], $cond->getEdgeTypesExcluded());
         $this->assertTrue($cond->isSuitableEdge($e1));
         $this->assertTrue($cond->isSuitableEdge($e2));
@@ -82,7 +82,7 @@ class ConditionsTest extends \Codeception\Test\Unit
         $this->assertFalse($cond->isSuitableEdge($e3));
 
         $cond->onlyEdgeTypes(null)->excludeEdgeTypes([2]);
-        $this->assertEquals(null, $cond->getEdgeTypesOnly());
+        $this->assertNull($cond->getEdgeTypesOnly());
         $this->assertEquals([2], $cond->getEdgeTypesExcluded());
         $this->assertTrue($cond->isSuitableEdge($e1));
         $this->assertTrue($cond->isSuitableEdge($e2));

--- a/tests/unit/ModelsTest.php
+++ b/tests/unit/ModelsTest.php
@@ -10,18 +10,18 @@ class ModelsTest extends \Codeception\Test\Unit
     public function testVertex()
     {
         $vertex = new Vertex(1, 2, ['test' => 3]);
-        $this->assertEquals(1, $vertex->getId());
-        $this->assertEquals(2, $vertex->getType());
+        $this->assertSame('1', $vertex->getId());
+        $this->assertSame('2', $vertex->getType());
         $this->assertEquals(['test' => 3], $vertex->getData());
     }
 
     public function testEdge()
     {
         $edge = new Edge(1, 2, 3, 4, 5.5);
-        $this->assertEquals(1, $edge->getId());
-        $this->assertEquals(2, $edge->getType());
-        $this->assertEquals(3, $edge->getFromId());
-        $this->assertEquals(4, $edge->getToId());
+        $this->assertSame('1', $edge->getId());
+        $this->assertSame('2', $edge->getType());
+        $this->assertSame('3', $edge->getFromId());
+        $this->assertSame('4', $edge->getToId());
         $this->assertEquals(5.5, $edge->getWeight());
     }
 }

--- a/tests/unit/PreloadedGraphRepositoryTest.php
+++ b/tests/unit/PreloadedGraphRepositoryTest.php
@@ -23,9 +23,9 @@ class PreloadedGraphRepositoryTest extends \Codeception\Test\Unit
         ];
         $repo = new PreloadedGraphRepository($vertexes, $connections);
 
-        $this->assertEquals(1, $repo->getVertexById(1)->getId());
-        $this->assertEquals(2, $repo->getVertexById(2)->getId());
-        $this->assertEquals(3, $repo->getVertexById(3)->getId());
+        $this->assertSame('1', $repo->getVertexById(1)->getId());
+        $this->assertSame('2', $repo->getVertexById(2)->getId());
+        $this->assertSame('3', $repo->getVertexById(3)->getId());
 
         $this->assertVertexIds(
             [],
@@ -186,24 +186,24 @@ class PreloadedGraphRepositoryTest extends \Codeception\Test\Unit
 
         /** @var Vertex $vertex */
         $vertex = $repo->getVertexById(1);
-        $this->assertEquals(1, $vertex->getId());
-        $this->assertEquals(null, $vertex->getData());
+        $this->assertSame('1', $vertex->getId());
+        $this->assertNull($vertex->getData());
 
         try {
             $repo->getVertexById(100);
             $this->expectError();
         } catch(RepositoryException $e) {
-            $this->assertEquals(RepositoryException::VERTEX_NOT_FOUND, $e->getCode());
+            $this->assertSame(RepositoryException::VERTEX_NOT_FOUND, $e->getCode());
         }
 
         $edge = $repo->getEdgeById(1);
-        $this->assertEquals(1, $edge->getId());
+        $this->assertSame('1', $edge->getId());
 
         try {
             $repo->getEdgeById(100);
             $this->expectError();
         } catch(RepositoryException $e) {
-            $this->assertEquals(RepositoryException::EDGE_NOT_FOUND, $e->getCode());
+            $this->assertSame(RepositoryException::EDGE_NOT_FOUND, $e->getCode());
         }
     }
 

--- a/tests/unit/PreloadedGraphTraverseTest.php
+++ b/tests/unit/PreloadedGraphTraverseTest.php
@@ -74,7 +74,7 @@ class PreloadedGraphTraverseTest extends Unit
             }
         }
         $this->assertEquals([2, 3, 1], $vertexIds);
-        $this->assertEquals(2, $loopsCount);
+        $this->assertSame(2, $loopsCount);
 
         $contexts = $traverse->generate(
             $repo->getVertexById(2),


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to make assert equals strict.
- Using the `assertNull` to let result be null.